### PR TITLE
[bug_fix] integer conversion for CO cv2.putText

### DIFF
--- a/1.1.3 - Data Collection/Raspberry Pi/pi-cam-capture.py
+++ b/1.1.3 - Data Collection/Raspberry Pi/pi-cam-capture.py
@@ -103,7 +103,8 @@ with PiCamera() as camera:
         # Draw countdown on screen
         cv2.putText(img,
                     str(countdown),
-                    (round(res_width / 2) - 5, round(res_height / 2)),
+                    (int(round(res_width / 2) - 5),
+                        int(round(res_height / 2))),
                     cv2.FONT_HERSHEY_PLAIN,
                     1,
                     (255, 255, 255))


### PR DESCRIPTION
cv2 expects int coordinates and that division may depending on the resolution, (and in fact returns), a float.